### PR TITLE
remove unnecessary loading of thm-restate from doc

### DIFF
--- a/doc/thmtools-manual.tex
+++ b/doc/thmtools-manual.tex
@@ -45,7 +45,7 @@
   }
 \usepackage{cleveref}[2010/05/01]
 
-\usepackage{thmtools, thm-restate}
+\usepackage{thmtools}
 \usepackage[unq]{unique}
 
 \providecommand\pkg[1]{\textsf{#1}}
@@ -677,7 +677,7 @@
   \autoref{thm:euclid} on p.\,\pageref{thm:euclid}: the true code used was
   \begin{source}
     \begin{preamble}[gobble=6]
-      \usepackage{thmtools, thm-restate}
+      \usepackage{thmtools}
       \declaretheorem{theorem}
     \end{preamble}
     \begin{body}[gobble=6]


### PR DESCRIPTION
Since `thm-restate` is loaded by `thmtools.sty`, there's no need to load it separately in the documentation or display it in the `restatable` example.