### PR TITLE
fix headindent -> qed in thm-ntheorem

### DIFF
--- a/source/thm-ntheorem.dtx
+++ b/source/thm-ntheorem.dtx
@@ -75,7 +75,7 @@
   }{%
     \thmt@notsupported
       {ntheorem without thmmarks option}%
-      {headindent}%
+      {qed}%
   }%
 }
 


### PR DESCRIPTION
The unsupported option here should be `qed`, not `headindent`