### PR TITLE
fix a few doc typos

### DIFF
--- a/doc/thmtools-manual.tex
+++ b/doc/thmtools-manual.tex
@@ -301,7 +301,7 @@
   also use |title=| and |heading=| instead of |name=|; they do exactly
   the same and hopefully one of these will be easy to remember for you.
 
-  Of course, you do not have to follow the abominal practice of numbering
+  Of course, you do not have to follow the abominable practice of numbering
   theorems, lemmas, etc., separately:  
   \begin{source}
   \begin{preamble}[gobble=4]
@@ -711,7 +711,7 @@
   p.\,\pageref{thm:euclid}, where the unstarred environment is used. (You can
   also use a starred environment and an unstarred command, in which case the
   behaviour is reversed.) Also, if you use \pkg{hyperref} (like you see in this manual), the links will lead you
-  to the unstarred occurence.
+  to the unstarred occurrence.
   
   Just to demonstrate that we also handle more involved cases, I repeat
   another theorem here, but this one was numbered within its section: note
@@ -969,7 +969,7 @@
 
   \key{bodyfont} 
     Value: \TeX\ code. Executed before the begin part of the theorem ends,
-    but before all afterheadhooks. Intended use it to put font switches here.
+    but before all postheadhooks. Intended use it to put font switches here.
   
   \key{headpunct}
     Value: \TeX\ code, usually a single character. Put at the end of the
@@ -990,7 +990,7 @@
     and |\NOTE|, which correspond to the (formatted, including the braces
     for |\NOTE| etc.) three parts of a theorem's head. This can be used to
     override the usual style ``1.1 Theorem (Foo)'', for example to let the
-    numbers protude in the margin or put them after the name.
+    numbers protrude in the margin or put them after the name.
     
     Additionally, a number of keywords are allowed here instead of \LaTeX\
     code:

--- a/source/thm-restate.dtx
+++ b/source/thm-restate.dtx
@@ -62,7 +62,7 @@
 % the original number. There is also a starred variant of the |restatable|
 % environment, where the first call doesn't determine the number, but a
 % later call to |\mylemma| without star would. Since the number is carried
-% around using \LaTeX' |\label| machanism, you'll need a rerun for things to
+% around using \LaTeX' |\label| mechanism, you'll need a rerun for things to
 % settle.
 %
 % \subsection{Restrictions}
@@ -78,7 +78,7 @@
 % %equations.) 
 % Note that you cannot successfully reference the equations
 % since all labels are disabled in the starred appearance. (The reference
-% will point at the unstarred occurence.)
+% will point at the unstarred occurrence.)
 %
 % You cannot nest
 % restatables either. You \emph{can} use the |\restatable|\dots|\endrestatable|

--- a/source/unique.dtx
+++ b/source/unique.dtx
@@ -136,7 +136,7 @@
 %    
 %    Warning if we have a second uniqmark this run around. Since this is
 %    checked immediately, we could give the line of the second
-%    occurence, but we do not do so for symmetry.
+%    occurrence, but we do not do so for symmetry.
 %    \begin{macrocode}
 \def\uniq@warnnotunique#1{%
   \PackageWarningNoLine{uniq}{%


### PR DESCRIPTION
All are spelling corrections except the change "afterheadhooks" to "postheadhooks" to match with the package terminology.