### PR TITLE
fix typos in manual

### DIFF
--- a/doc/thmtools-manual.tex
+++ b/doc/thmtools-manual.tex
@@ -785,7 +785,7 @@
     \emph{optional} argument, which will go into the list of theorems. Be
     aware that since we already are within an optional argument, you have to
     use an extra level of curly braces:
-    |\begin{theorem}[name={[Short name]A long name,...]}|
+    |\begin{theorem}[name={[Short name]A long name,...}]|
     
     \item[label] This will issue a |\label| command after the head. Not very
     useful, more of a demo.


### PR DESCRIPTION
The braces and brackets in Section 1.6 of the manual (in the description of `name` argument) did not match. I fixed this typo. 