### PR TITLE
add braces to restate key example

### DIFF
--- a/doc/thmtools-manual.tex
+++ b/doc/thmtools-manual.tex
@@ -799,7 +799,7 @@
     wrapping this theorem in a restatable environment. (It probably still fails
     in cases that I didn't think of.) This key also accepts an optional
     argument: when restating, the restate key is replaced by this argument,
-    for example, |restate=[name=Boring rehash]foo| will result in a
+    for example, |restate={[name=Boring rehash]foo}| will result in a
     different name. (Be aware that it is possible to give the same key
     several times, but I don't promise the results. In case of the name key,
     the names happen to override one another.)


### PR DESCRIPTION
It needs braces to not confuse the argument processor with unbraced brackets