### PR TITLE
small updates to thmtools-manual.tex

### DIFF
--- a/doc/thmtools-manual.tex
+++ b/doc/thmtools-manual.tex
@@ -183,7 +183,7 @@
   of the ordinary, browse the examples in \autoref{cha:impatient}. If you're
   here because the other packages you've tried so far just can't do what you
   want, take inspiration from \autoref{cha:extravagant}. If you're a repeat
-  customer, you're most likely to be interested in the refence section in
+  customer, you're most likely to be interested in the reference section in
   \autoref{cha:reference}.
   
   \begin{multicols}{2}[\section*{\contentsname}]

--- a/doc/thmtools-manual.tex
+++ b/doc/thmtools-manual.tex
@@ -46,7 +46,6 @@
 \usepackage{cleveref}[2010/05/01]
 
 \usepackage{thmtools}
-\usepackage[unq]{unique}
 
 \providecommand\pkg[1]{\textsf{#1}}
 \providecommand\Thmtools{\pkg{Thmtools}\xspace}
@@ -360,7 +359,6 @@
   \begin{preamble}[gobble=4]
     \usepackage{amsthm}
     \usepackage{thmtools}
-    \usepackage[unq]{unique}
     \declaretheorem[numbered=unless unique]{singleton}
     \declaretheorem[numbered=unless unique]{couple}
   \end{preamble}
@@ -509,11 +507,11 @@
   \end{body}
   \end{source}
   \begin{result}
-    \begin{BoxI}
+    \begin{BoxI}[Euclid]
       For every prime $p$, there is a prime $p'>p$.
       In particular, there are infinitely many primes.
     \end{BoxI}
-    \begin{BoxII}
+    \begin{BoxII}[Euclid]
       For every prime $p$, there is a prime $p'>p$.
       In particular, there are infinitely many primes.
     \end{BoxII}


### PR DESCRIPTION
Since loading the `unique` package is automatically done when `numbered=unless unique` is called, it's unnecessary to load the package explicitly so I removed this from the doc preamble and in the example. Also, I added `[Euclid]` to the thmbox examples so that the output matches the listing, and fixed a small typo.